### PR TITLE
 Remove the entry with old id from the cache (https://github.com/confluentinc/librdkafka/pull/4864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ librdkafka v2.5.3 is a feature release.
 
 ## Fixes
 
+* Fix crashes (null-pointer access) in rd_kafka_metadata_cache_entry_by_id_cmp() during rd_avl_insert()
+
 ### Telemetry fixes
 
 * Issue: #4833

--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -379,7 +379,8 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
                 /* If topic id isn't zero insert cache entry into this tree */
                 old_by_id = RD_AVL_INSERT(&rk->rk_metadata_cache.rkmc_avl_by_id,
                                           rkmce, rkmce_avlnode_by_id);
-        } else if (old && !RD_KAFKA_UUID_IS_ZERO(
+        } 
+        if (old && !RD_KAFKA_UUID_IS_ZERO(
                               old->rkmce_metadata_internal_topic.topic_id)) {
                 /* If it had a topic id, remove it from the tree */
                 RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl_by_id, old);


### PR DESCRIPTION
Porting https://github.com/confluentinc/librdkafka/pull/4864 to the `2.6.1-gr` release branch