### PR TITLE
Add sasl2 abi v2 build and include all flavours for linux-arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,11 +267,10 @@ jobs:
         shell: pwsh
         run: |
           # Different packaging for tagged vs untagged builds
-          $vstring = "2.11.0-"
-          if ($env:GITHUB_REF -match '^refs/tags/') {
-            $vstring += "gr"
+          if ($env:GITHUB_REF -match '^refs/tags/v') {
+            $vstring = $env:GITHUB_REF -replace '^refs/tags/v', ''
           } else {
-            $vstring += "ci-$env:GITHUB_RUN_ID"
+            $vstring = "$((Get-Content .\vcpkg.json | ConvertFrom-Json).version)-ci-$($env:GITHUB_RUN_ID)"
           }
 
           mkdir packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,13 @@ jobs:
       matrix:
         include:
           - name: "centos8 glibc +gssapi"
-            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-x64__lnk-std__extra-gssapi
+            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-x64__lnk-std__extra-gssapi__sasl2abi-v3
             image: quay.io/pypa/manylinux_2_28_x86_64:2024.07.01-1
             extra_args: ""
+          - name: "centos8 glibc +gssapi +sasl2abi-v2"
+            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-x64__lnk-std__extra-gssapi__sasl2abi-v2
+            image: quay.io/pypa/manylinux_2_28_x86_64:2024.07.01-1
+            extra_args: "--sasl2-abi-v2"
           - name: "centos8 glibc"
             artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-x64__lnk-all
             image: quay.io/pypa/manylinux_2_28_x86_64:2024.07.01-1
@@ -151,9 +155,13 @@ jobs:
       matrix:
         include:
           - name: "centos8 glibc +gssapi"
-            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-arm64__lnk-std__extra-gssapi
+            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-arm64__lnk-std__extra-gssapi__sasl2abi-v3
             image: quay.io/pypa/manylinux_2_28_aarch64:2024.07.01-1
             extra_args: ""
+          - name: "centos8 glibc +gssapi +sasl2abi-v2"
+            artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-arm64__lnk-std__extra-gssapi__sasl2abi-v2
+            image: quay.io/pypa/manylinux_2_28_aarch64:2024.07.01-1
+            extra_args: "--sasl2-abi-v2"
           - name: "centos8 glibc"
             artifact_key: p-librdkafka__plat-linux__dist-centos8__arch-arm64__lnk-all
             image: quay.io/pypa/manylinux_2_28_aarch64:2024.07.01-1

--- a/packaging/nuget/nugetpackage.py
+++ b/packaging/nuget/nugetpackage.py
@@ -71,10 +71,40 @@ class NugetPackage (Package):
         Mapping({'arch': 'x64',
                  'plat': 'linux',
                  'dist': 'centos8',
-                 'lnk': 'std'},
+                 'lnk': 'std',
+                 'sasl2abi': 'v3'},
                 'librdkafka.tgz',
                 './usr/local/lib/librdkafka.so.1',
                 'runtimes/linux-x64/native/librdkafka.so'),
+        # Linux glibc centos8 arm64 with GSSAPI
+        Mapping({'arch': 'arm64',
+                 'plat': 'linux',
+                 'dist': 'centos8',
+                 'lnk': 'std',
+                 'sasl2abi': 'v3'},
+                'librdkafka.tgz',
+                './usr/local/lib/librdkafka.so.1',
+                'runtimes/linux-arm64/native/librdkafka.so'),
+
+        # Linux glibc centos8 x64 with GSSAPI and SASL2 v2 ABI
+        Mapping({'arch': 'x64',
+                 'plat': 'linux',
+                 'dist': 'centos8',
+                 'lnk': 'std',
+                 'sasl2abi': 'v2'},
+                'librdkafka.tgz',
+                './usr/local/lib/librdkafka.so.1',
+                'runtimes/linux-x64/native/sasl2abiv2-librdkafka.so'),
+        # Linux glibc centos8 arm64 with GSSAPI and SASL2 v2 ABI
+        Mapping({'arch': 'arm64',
+                 'plat': 'linux',
+                 'dist': 'centos8',
+                 'lnk': 'std',
+                 'sasl2abi': 'v2'},
+                'librdkafka.tgz',
+                './usr/local/lib/librdkafka.so.1',
+                'runtimes/linux-arm64/native/sasl2abiv2-librdkafka.so'),
+
         # Linux glibc centos8 x64 without GSSAPI (no external deps)
         Mapping({'arch': 'x64',
                  'plat': 'linux',
@@ -90,7 +120,7 @@ class NugetPackage (Package):
                  'lnk': 'all'},
                 'librdkafka.tgz',
                 './usr/local/lib/librdkafka.so.1',
-                'runtimes/linux-arm64/native/librdkafka.so'),
+                'runtimes/linux-arm64/native/centos8-librdkafka.so'),
 
         # Linux musl alpine x64 without GSSAPI (no external deps)
         Mapping({'arch': 'x64',
@@ -100,6 +130,14 @@ class NugetPackage (Package):
                 'librdkafka.tgz',
                 './usr/local/lib/librdkafka.so.1',
                 'runtimes/linux-x64/native/alpine-librdkafka.so'),
+        # Linux musl alpine arm64 without GSSAPI (no external deps)
+        Mapping({'arch': 'arm64',
+                 'plat': 'linux',
+                 'dist': 'alpine',
+                 'lnk': 'all'},
+                'librdkafka.tgz',
+                './usr/local/lib/librdkafka.so.1',
+                'runtimes/linux-arm64/native/alpine-librdkafka.so'),
 
         # Common Win runtime
         Mapping({'arch': 'x64',


### PR DESCRIPTION
- add an extra Linux build linking to `libsasl2.so.2` instead of `libsasl2.so.3`, named `sasl2abiv2-librdkafka.so` - this build can then be consumed by the .NET bindings to enable GSSAPI support on Debian-based distros.
- add the same builds as `linux-x64` for `linux-arm64` to enable alpine/musl and GSSAPI on arm64 Linux platforms
- Compute the version either from the tag or from `vcpkg.json` to future-proof building our forks